### PR TITLE
Handle cases with no BatchNorm hooks

### DIFF
--- a/data_generate/distill_data.py
+++ b/data_generate/distill_data.py
@@ -221,10 +221,14 @@ class DistillData(object):
                     mean_loss += MSE_loss(self.mean_list[num], self.teacher_running_mean[num].detach())
                     var_loss += MSE_loss(self.var_list[num], self.teacher_running_var[num].detach())
 
-                mean_loss = mean_loss / len(self.mean_list)
-                var_loss = var_loss / len(self.mean_list)
-
-                total_loss = mean_loss + var_loss + loss_target
+                num_bn = len(self.mean_list)
+                if num_bn == 0:
+                    print("Warning: no BatchNorm hooks triggered; skipping BN losses.")
+                    total_loss = loss_target
+                else:
+                    mean_loss = mean_loss / num_bn
+                    var_loss = var_loss / num_bn
+                    total_loss = mean_loss + var_loss + loss_target
                 print(f"Batch: {i}, Iter: {it}, LR: {optimizer.state_dict()['param_groups'][0]['lr']:.4f}, "
                       f"Mean Loss: {mean_loss.item():.4f}, Var Loss: {var_loss.item():.4f}, "
                       f"Target Loss: {loss_target.item():.4f}")

--- a/trainer_direct.py
+++ b/trainer_direct.py
@@ -281,9 +281,14 @@ class Trainer(object):
 					BNS_loss += self.MSE_loss(self.mean_list[num], self.teacher_running_mean[num]) + self.MSE_loss(
 						self.var_list[num], self.teacher_running_var[num])
 
-				BNS_loss = BNS_loss / len(self.mean_list)
-				# loss of Generator
-				loss_G = loss_one_hot + 0.1 * BNS_loss
+				num_bn = len(self.mean_list)
+				if num_bn == 0:
+					print("Warning: no BatchNorm hooks triggered; skipping BN losses.")
+					loss_G = loss_one_hot
+				else:
+					BNS_loss = BNS_loss / num_bn
+					# loss of Generator
+					loss_G = loss_one_hot + 0.1 * BNS_loss
 				self.backward_G(loss_G)
 				output = self.model(images.detach())
 				loss_S = torch.zeros(1).to(self.args.local_rank)


### PR DESCRIPTION
## Summary
- guard against missing BatchNorm hooks in distilled data generation
- skip BN losses when no BN hooks fire during direct training

## Testing
- `python -m py_compile data_generate/distill_data.py trainer_direct.py`

------
https://chatgpt.com/codex/tasks/task_e_6876f63b1c78832a8577b2d04d689bf4